### PR TITLE
Adding .travis.yml, fixiing lint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,12 +2,7 @@
   "extends": "stylelint-config-sass-guidelines",
   "rules": {
     "max-nesting-depth": 2,
-    "scss/at-mixin-pattern": "^(terra-)[a-z]+([a-z0-9-]+[a-z0-9]+)?$",
-    "selector-class-pattern": [
-      "^terra-(?:[A-Z][a-zA-Z0-9]+)*(?:-[a-z0-9][a-zA-Z0-9]+)*?(?:--[a-z0-9][a-zA-Z0-9-]+)*?$|^(?:terra-)?(?:u|is|has|js)(?:-[a-z0-9][a-zA-Z0-9-]*)+$",
-      {
-        "message": "Class names should match the SUIT CSS naming convention"
-      }
-    ]
+    "scss/at-mixin-pattern": null,
+    "selector-class-pattern": null
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+
+env:
+  - TRAVIS_NODE_VERSION="node"
+  - TRAVIS_NODE_VERSION="6.3.0"
+
+install:
+  - npm install
+
+before_script:
+  - npm run webpack
+
+script:
+  - npm run lint
+  - bundle exec rspec

--- a/app/modules/terra-ui.scss
+++ b/app/modules/terra-ui.scss
@@ -19,23 +19,23 @@ $terra-bidi: true;
 
 // horizontal scrolling on code
 pre {
-    overflow-x: auto;
+  overflow-x: auto;
 }
 
 pre code {
-    overflow-wrap: normal;
-    white-space: pre;
+  overflow-wrap: normal;
+  white-space: pre;
 }
 
 // background/padding on code
-.tui-html-code{
-  padding: 1rem;
+.tui-html-code {
   background-color: #f7f7f9;
+  padding: 1rem;
 }
 
-.tui-haml-code{
-  padding: 1rem;
+.tui-haml-code {
   background-color: #daf3ff;
+  padding: 1rem;
 }
 
 // grid demo styling


### PR DESCRIPTION
### Summary
We are currently using the default configuration for Travis-CI which runs ruby RSpec tests.  I am adding a .travis-ci.yml file for additional configuration. 

By default, Travis-CI uses .ruby-version for ruby version

I added `node` and `6.3.0` to test with the most recent version of node and the version we are using. 

It will now run RSpec tests and lint tests.


I disabled stylelint `selector-class-pattern` and `scss/at-mixin-pattern` rules for this application. 