### PR TITLE
react-router-url

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   root to: 'home#index'
   get 'home/index'
+
+  # React Router needs a wildcard https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/config/routes.rb#L12
+  get "components(/*all)", to: "home#index"
 end


### PR DESCRIPTION
### Summary
This fixes the react-router URLs. Currently, if you go to https://terra-ui.herokuapp.com/components/core/badge, the route does not exist. This is because this route is generated by react-router. This pr fixes that issue. 

This fix is the same thing react_on_rails suggests.
https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/config/routes.rb#L13


Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
