### PR TITLE
Fix code contrast issue

### DIFF
--- a/client/app/bundles/App/Components/Index.scss
+++ b/client/app/bundles/App/Components/Index.scss
@@ -26,4 +26,8 @@
     background-color: #ccc;
     outline: none;
   }
+
+  .markdown-body code {
+    background-color: #f6f8fa; // fixes contrast issue of code elements
+  }
 }


### PR DESCRIPTION
### Summary
The current styling of the `<code>` element within markdown content has some contrast issues. We don't author these styles, we pull in https://github.com/sindresorhus/github-markdown-css. 

This code is to override the CSS from the github-markdown-css dependency. In the future, we may author markdown content ourselves instead of pulling in github-markdown-css.

@cerner/terra